### PR TITLE
Fetch port from environment variables

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ Set the environment variables to configure the Go-Mail-Admin
 export GOMAILADMIN_DB="vmail:vmailpassword@tcp(127.0.0.1:3306)/vmail"
 export GOMAILADMIN_APIKEY=abc
 export GOMAILADMIN_APISECRET=abc
+export GOMAILADMIN_PORT=3001
 ```
 
 Then you can start the Go-Mail-Admin with the following command
@@ -23,17 +24,18 @@ Then you can start the Go-Mail-Admin with the following command
 ./go-mail-admin-with-gui-<VERSION>
 ```
 
-After that you can open the gui via http at http://servername:3001
+After that you can open the gui via http at http://servername:3001 (or your specified custom port)
 
 # Usage
 ## Config
-The script can be configurated with environment variables. The following settings are possible:
+The script can be configured with environment variables. The following settings are possible:
 
 | Key | Required | Notice |
 | --- | ---      | --- |
 | GOMAILADMIN_DB | Yes | Database connection string like 'username:password@tcp(127.0.0.1:3306)/database' |
 | GOMAILADMIN_APIKEY | No | API Key for HTTP-Basic-Auth (just use if APISECRET  is set too)  |
 | GOMAILADMIN_APISECRET | No | API Secret for HTTP-Basic-Auth (just use if APIKEY is set too) |
+| GOMAILADMIN_PORT | No | Port at which is bound (default: 3001) |
 
 ## API
 ### Domains

--- a/go-mail-admin.service
+++ b/go-mail-admin.service
@@ -16,6 +16,7 @@ RestartSec=3
 Environment="GOMAILADMIN_DB=vmail:vmailpassword@tcp(127.0.0.1:3306)/vmail"
 Environment="GOMAILADMIN_APIKEY=abc"
 Environment="GOMAILADMIN_APISECRET=abc"
+Environment="GOMAILADMIN_PORT=3001"
 
 [Install]
 WantedBy=multi-user.target

--- a/install.md
+++ b/install.md
@@ -34,7 +34,7 @@ Create a new file called /etc/systemd/system/go-mail-admin.service
 ```
 sudo nano /etc/systemd/system/go-mail-admin.service
 ```
-copy the content from the [sample file](https://github.com/kekskurse/go-mail-admin/blob/master/go-mail-admin.service) and change the 3 Environment settings!
+copy the content from the [sample file](https://github.com/kekskurse/go-mail-admin/blob/master/go-mail-admin.service) and change the 4 environment settings!
 
 ## Enabled and Start Service
 Run the following command to enable and start the service. After it the service will autostart always.

--- a/mailserver-configurator-interface/main.go
+++ b/mailserver-configurator-interface/main.go
@@ -129,6 +129,10 @@ func main() {
 	log.Println("Start Go Mail Admin")
 	connectToDb()
 	router := defineRouter()
-	http.ListenAndServe(":3001", router)
+	port := getConfigVariable("PORT")
+	if port == "" {
+		port = "3001"
+	}
+	http.ListenAndServe(":" + port, router)
 	fmt.Println("Done")
 }


### PR DESCRIPTION
Hey there, 
thank you for this cool piece of software. I was unable to deploy it yet because I needed to change port number first. I think this is a quite common scenario, I have a somewhat structured way to define ports for my applications and I think that port 3001 is quite common so it's not unlikely to already be in use. 

This PR fetches the port from the environment variable `GOMAILADMIN_PORT` and updates the docs for this project accordingly. I hope this tiny change fits your code style, I did my best :joy: 

Just a side note: You repeat yourself in first giving examples for the config options and having that table overview in the Readme again. I recommend to only have one example at the top (the necessary `GOMAILADMIN_DB`) and the full config doc below. 

Thank you very much.