### PR TITLE
Fix typo, used example.com as example domain, pulls unrolled from github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ interface-copy-client:
 interface-install-deps:
 	go get github.com/go-sql-driver/mysql
 	go get github.com/go-chi/cors
-	go get gopkg.in/unrolled/render.v1
+	go get github.com/unrolled/render
 	go get github.com/go-chi/chi
 	go get github.com/rakyll/statik
 	go get github.com/99designs/basicauth-go

--- a/mailserver-configurator-client/src/components/AliasChart.vue
+++ b/mailserver-configurator-client/src/components/AliasChart.vue
@@ -20,7 +20,7 @@
 
                 this.renderChart(
                     {
-                        labels: ["Einabled", "Disabled"],
+                        labels: ["Enabled", "Disabled"],
                         datasets: [
                             {
                                 backgroundColor: ["#4CAF50", "#F44336"],

--- a/mailserver-configurator-client/src/views/Domains.vue
+++ b/mailserver-configurator-client/src/views/Domains.vue
@@ -9,7 +9,7 @@
                 <v-card-text>
                     <v-text-field
                             v-model="newDomain"
-                            placeholder="domain.de"
+                            placeholder="example.com"
                     ></v-text-field>
                     <v-btn @click="addDomain()">Add Domain</v-btn><br><br>
 


### PR DESCRIPTION
- typo in mailserver-configurator-client/src/components/AliasChart.vue: 'Einabled' → 'Enabled'
- uses 'example.com' as placeholder domain in mailserver-configurator-client/src/views/Domains.vue
- pulls unrolled go dependency from github.com/unrolled/render in Makefile as this is the required path by mailserver-configurator-interface/featuretoggle.go