### PR TITLE
Fix/readme envvar names

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -19,8 +19,22 @@ To Access the API or the Webfrontend a HTTP-Basic-Auth authorisation is requeste
 ## Username
 Access via Username/Password with the Webfronend.
 
-* GOMAILADMIN_AUTH_USERNAME_USERNAME -> Username
-* GOMAILADMIN_AUTH_USERNAME_PASSWORD -> Password
+Make sure to configure: 
+
+* `GOMAILADMIN_AUTH_METHOD=Username`
+* `GOMAILADMIN_AUTH_Username_Username` -> Set your username
+* `GOMAILADMIN_AUTH_Username_Password` -> Set your Password
+
+for example - in the systemd init file: 
+
+```
+...
+Environment="GOMAILADMIN_AUTH_METHOD=Username"
+Environment="GOMAILADMIN_AUTH_Username_Username=myusername"
+Environment="GOMAILADMIN_AUTH_Username_Password=mypassword"
+...
+```
+
 
 ## DontStart
 Just the default, the Project will stop with a panic.

--- a/docs/go-mail-admin.service
+++ b/docs/go-mail-admin.service
@@ -14,10 +14,11 @@ StandardError=syslog
 Restart=always
 RestartSec=3
 Environment="GOMAILADMIN_DB=vmail:vmailpassword@tcp(127.0.0.1:3306)/vmail"
-Environment="GOMAILADMIN_APIKEY=abc"
-Environment="GOMAILADMIN_APISECRET=abc"
 Environment="GOMAILADMIN_ADDRESS=127.0.0.1"
 Environment="GOMAILADMIN_PORT=3001"
+Environment="GOMAILADMIN_AUTH_METHOD=Username"
+Environment="GOMAILADMIN_AUTH_Username_Username=myusername"
+Environment="GOMAILADMIN_AUTH_Username_Password=mypassword"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix the uppercase/lowercase letters in the auth.md readme and update the example systemd service file to the latest syntax. 